### PR TITLE
Add BOE ETL example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install backend deps
+        run: |
+          cd backend
+          npm install
+      - name: Run backend tests
+        run: |
+          cd backend
+          npm test
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          npm install
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Python tests
+        run: |
+          pytest

--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ npm install
 npm run dev
 npm test
 ```
+
+## ETL BOE Administradores Concursales
+
+En la carpeta `edictos` se incluye un ejemplo sencillo de ETL en Python que descarga el feed del BOE, filtra los nombramientos de administradores concursales y da de alta oportunidades en Odoo mediante XML-RPC.
+
+### Comandos
+```bash
+cd edictos
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest
+```

--- a/edictos/README.md
+++ b/edictos/README.md
@@ -1,0 +1,29 @@
+# BOE Administradores Concursales ETL
+
+Este proyecto contiene un pequeño ejemplo de ETL para localizar los edictos de nombramiento de administrador concursal publicados en el BOE. Extrae los datos básicos y crea oportunidades en Odoo mediante XML-RPC.
+
+## Instalación
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Uso
+
+```
+python etl.py
+```
+
+El script lee la URL del feed desde la variable de entorno `BOE_FEED_URL` y las credenciales de Odoo desde `ODOO_URL`, `ODOO_DB`, `ODOO_USER` y `ODOO_PASSWORD`.
+
+## Cron
+
+Para programar la ejecución diaria se puede añadir una entrada en `crontab`:
+
+```
+0 7 * * * /ruta/a/venv/bin/python /ruta/al/proyecto/edictos/etl.py >> /var/log/boe_etl.log 2>&1
+```
+
+

--- a/edictos/boe_parser.py
+++ b/edictos/boe_parser.py
@@ -1,0 +1,33 @@
+import os
+from typing import List, Dict
+import feedparser
+import requests
+from lxml import etree
+
+
+def download_feed(url: str) -> bytes:
+    """Download the XML feed from BOE."""
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.content
+
+
+def parse_feed(xml_bytes: bytes) -> List[Dict[str, str]]:
+    """Parse the RSS feed and extract entries about administradores concursales."""
+    feed = feedparser.parse(xml_bytes)
+    results = []
+    for entry in feed.entries:
+        title = entry.get("title", "")
+        if "administrador concursal" not in title.lower():
+            continue
+        link = entry.get("link", "")
+        summary = entry.get("summary", "")
+        results.append({"title": title, "link": link, "summary": summary})
+    return results
+
+
+def get_feed_url() -> str:
+    return os.getenv("BOE_FEED_URL", "https://www.boe.es/rss/BOE-S-0100.xml")
+
+
+__all__ = ["download_feed", "parse_feed", "get_feed_url"]

--- a/edictos/etl.py
+++ b/edictos/etl.py
@@ -1,0 +1,44 @@
+import logging
+from datetime import datetime
+from .boe_parser import get_feed_url, download_feed, parse_feed
+from .odoo_client import OdooClient
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    url = get_feed_url()
+    logger.info("Descargando feed %s", url)
+    try:
+        xml_bytes = download_feed(url)
+    except Exception as exc:
+        logger.error("Error descargando feed: %s", exc)
+        return
+
+    entries = parse_feed(xml_bytes)
+    if not entries:
+        logger.info("No se encontraron nombramientos de AC")
+        return
+
+    odoo = None
+    try:
+        odoo = OdooClient()
+    except Exception as exc:
+        logger.error("No se pudo conectar con Odoo: %s", exc)
+        return
+
+    for entry in entries:
+        values = {
+            "name": f"Nombramiento AC - {entry['title']}",
+            "description": entry['summary'],
+        }
+        try:
+            lead_id = odoo.create_lead(values)
+            logger.info("Creado lead %s", lead_id)
+        except Exception as exc:
+            logger.error("Error creando lead en Odoo: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/edictos/odoo_client.py
+++ b/edictos/odoo_client.py
@@ -1,0 +1,29 @@
+from typing import Dict, Any
+import os
+import xmlrpc.client
+
+
+class OdooClient:
+    def __init__(self):
+        url = os.getenv("ODOO_URL")
+        db = os.getenv("ODOO_DB")
+        user = os.getenv("ODOO_USER")
+        password = os.getenv("ODOO_PASSWORD")
+        if not all([url, db, user, password]):
+            raise ValueError("Missing Odoo configuration")
+        self.common = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/common")
+        uid = self.common.authenticate(db, user, password, {})
+        self.models = xmlrpc.client.ServerProxy(f"{url}/xmlrpc/2/object")
+        self.db = db
+        self.uid = uid
+        self.password = password
+
+    def create_lead(self, values: Dict[str, Any]) -> int:
+        return self.models.execute_kw(
+            self.db,
+            self.uid,
+            self.password,
+            "crm.lead",
+            "create",
+            [values],
+        )

--- a/edictos/sample_rss.xml
+++ b/edictos/sample_rss.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>BOE</title>
+<item>
+<title>Nombramiento de Administrador Concursal - EmpresaXYZ</title>
+<link>https://www.boe.es/diario_boe/txt.php?id=BOE-B-2025-1234</link>
+<description>Texto del anuncio con email ac@example.com y telefono 123456789.</description>
+</item>
+<item>
+<title>Otro anuncio</title>
+<link>https://www.boe.es/diario_boe/txt.php?id=BOE-B-2025-9999</link>
+<description>No relacionado</description>
+</item>
+</channel>
+</rss>

--- a/edictos/tests/test_etl.py
+++ b/edictos/tests/test_etl.py
@@ -1,0 +1,11 @@
+import os
+from edictos.boe_parser import parse_feed
+
+
+def test_parse_feed():
+    path = os.path.join(os.path.dirname(__file__), "..", "sample_rss.xml")
+    with open(path, "rb") as f:
+        xml = f.read()
+    items = parse_feed(xml)
+    assert len(items) == 1
+    assert items[0]["title"].startswith("Nombramiento de")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+feedparser
+requests
+lxml


### PR DESCRIPTION
## Summary
- add example ETL in `edictos` folder for scraping BOE RSS
- integrate simple Odoo XML-RPC client
- document setup in README
- configure GitHub Actions CI

## Testing
- `npm test` in backend
- `npm test` in frontend (terminated watcher)
- `pytest edictos/tests/test_etl.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fbe7362c832885f38a12367c5f53